### PR TITLE
Fix the link error for Neovim in setup of editors in docs.

### DIFF
--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -28,9 +28,9 @@ For more documentation on the Ruff extension, refer to the
 
 ## Neovim
 
-The [`nvim-lspconfig`](https://github/neovim/nvim-lspconfig) plugin can be used to configure the
+The [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin can be used to configure the
 Ruff Language Server in Neovim. To set it up, install
-[`nvim-lspconfig`](https://github/neovim/nvim-lspconfig) plugin, set it up as per the
+[`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin, set it up as per the
 [configuration](https://github.com/neovim/nvim-lspconfig#configuration) documentation, and add the
 following to your `init.lua`:
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix Gihub link for Neovim setup editors .

## Test Plan
Just click the link on Github to test
<!-- How was it tested? -->
